### PR TITLE
adds check to internal folder matching apworld name

### DIFF
--- a/manual_checker/extension.py
+++ b/manual_checker/extension.py
@@ -159,6 +159,11 @@ class ManualChecker(Extension):
                 elif fn.endswith('.py'):
                     self.parse_source_code(asts, report, zf, info, fn)
 
+        zp = zipfile.Path(path)
+        if not (zp / zp.filename.name[:-8] / "__init__.py").exists():
+            # [:-8] to strip ".apworld" from filename
+            reports[zp.filename.name] = f"Unexpected Folder Structure found, expected __init__.py in {zp.filename.name}/{zp.filename.name[:-8]} but was not found."
+
         if not [fn for fn in asts if '/' not in fn]:
             init_location = [p.filename for p in zf.infolist() if p.filename.endswith('__init__.py')][0]
             subfolder = init_location.split('/')[0] + '/'

--- a/manual_checker/extension.py
+++ b/manual_checker/extension.py
@@ -160,9 +160,9 @@ class ManualChecker(Extension):
                     self.parse_source_code(asts, report, zf, info, fn)
 
         zp = zipfile.Path(path)
-        if not (zp / zp.filename.name[:-8] / "__init__.py").exists():
+        if not (zp / zp.filename.stem / "__init__.py").exists():
             # [:-8] to strip ".apworld" from filename
-            reports[zp.filename.name] = f"Unexpected Folder Structure found, expected __init__.py in {zp.filename.name}/{zp.filename.name[:-8]} but was not found."
+            report.errors.setdefault(zp.filename.name,[]).append(f"Unexpected Folder Structure found, expected __init__.py in {zp.filename.name}/{zp.filename.stem} but was not found.")
 
         if not [fn for fn in asts if '/' not in fn]:
             init_location = [p.filename for p in zf.infolist() if p.filename.endswith('__init__.py')][0]


### PR DESCRIPTION
tested as a separate function
```py
def assert_zip(path: str) -> bool:
    zp = zipfile.Path(path)
    # using [:-4] because my test data was just using ".zip"
    return (zp / zp.filename.name[:-4] / "foo.txt").exists()
```
against the following files using both a relative and absolute path
* folder zipped as expected
* folder contents zipped (expect fail)
* folder zipped but then renamed (expect fail)
* folder zipped with manifest outside the folder
* folder zipped w/ manifest etc. but then renamed (expect fail)

was unsure how exactly you wanted the code formatted / structured / or how to best actually add the error so i just threw something that looked correct at the fan (especially because I'm unsure how to fully end to end test the bot)